### PR TITLE
Update B9TankTypes.cfg

### DIFF
--- a/GameData/SimpleConstruction/Compatibility/SimpleConstruction/B9TankTypes.cfg
+++ b/GameData/SimpleConstruction/Compatibility/SimpleConstruction/B9TankTypes.cfg
@@ -1,12 +1,12 @@
-// B9TankTypes.cfg v1.0.1.0
-// SimpleConstruction! (SCON!)!
+// B9TankTypes.cfg v1.0.2.0
+// SimpleConstruction! (SCON!)
 // created: 
-// updated: 01 Jun 2021
+// updated: 14 Mar 2022
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,SimpleConstruction]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,SimpleConstruction]
 {
 	name = SCRocketParts
-	title = RocketParts
+	title = #EL_RocketParts_displayName // RocketParts
 	tankMass = 0.0005
 	tankCost = 100
 	percentFilled = 100
@@ -17,10 +17,10 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,SimpleConstruction]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[SimpleConstruction]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,SimpleConstruction]
 {
 	name = SCMetal
-	title = Metal
+	title = #EL_Metal_displayName // Metal
 	tankMass = 0.0005
 	tankCost = 100
 	percentFilled = 100
@@ -31,10 +31,10 @@ B9_TANK_TYPE:NEEDS[SimpleConstruction]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[SimpleConstruction]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,SimpleConstruction]
 {
 	name = Ore
-	title = Ore
+	title = #autoLOC_501007 = Ore // Ore
 	tankMass = 0.0005
 	tankCost = 100
 	percentFilled = 0
@@ -45,7 +45,7 @@ B9_TANK_TYPE:NEEDS[SimpleConstruction]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,SimpleConstruction]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,SimpleConstruction]
 {
 	name = SCCombo
 	tankMass = 0.0005
@@ -71,5 +71,4 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,SimpleConstruction]
 	}
 }
 
-// GPLv2
-// zer0Kerbal
+// CC BY-NC-SA 3.0 Unported by zer0Kerbal


### PR DESCRIPTION
### Updated

* [B9TankTypes.cfg] v1.0.2.0
  * Update :NEEDS
    * was: B9_TANK_TYPE:NEEDS[CommunityResourcePack,SimpleConstruction]
    * is now: B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,SimpleConstruction]
  * closes #76 - Sandcastle compatibility

### Localization

* [B9TankTypes.cfg] v1.0.2.0
  * Update :NEEDS
    * was: B9_TANK_TYPE:NEEDS[CommunityResourcePack,SimpleConstruction]
    * is now: B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,SimpleConstruction]
  * `SCRocketParts`
    * [title] was = RocketParts, now is = #EL_RocketParts_displayName // RocketParts`
  * `SCMetal`  
    * [title] was = Metal, now is = #EL_Metal_displayName // Metal
  * 'Ore'
    * [title[ was = Ore, now is = #autoLOC_501007 = Ore // Ore
  * closes #78 - Localize [B9TankTypes.cfg] v1.0.2.0